### PR TITLE
Don't break code description lines mid-word

### DIFF
--- a/client/app/main/main.scss
+++ b/client/app/main/main.scss
@@ -140,7 +140,6 @@
     display: block;
     line-height: 20px;
     width:100%;
-    word-break: break-all;
 }
 
 .codeLang {


### PR DESCRIPTION
English is hard to read when lines break mid-word, for example:

```
Easy implementation of various shapes and patterns. Many shapes and patterns are made wit
h simple and understandable manner.
```
